### PR TITLE
Remove deploy double wrap

### DIFF
--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -1579,7 +1579,6 @@ export function JsonRpcContextProvider({
             },
           },
         });
-        console.log("RESULT: ", JSON.stringify(result));
         const signedDeploy = DeployUtil.deployFromJson(result).unwrap();
         const hash = await casperClient.putDeploy(signedDeploy);
         return {

--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -1574,12 +1574,12 @@ export function JsonRpcContextProvider({
           request: {
             method,
             params: {
-              deploy: DeployUtil.deployToJson(transferDeploy),
+              deploy: DeployUtil.deployToJson(transferDeploy).deploy,
               address,
             },
           },
         });
-
+        console.log("RESULT: ", JSON.stringify(result));
         const signedDeploy = DeployUtil.deployFromJson(result).unwrap();
         const hash = await casperClient.putDeploy(signedDeploy);
         return {

--- a/wallets/react-wallet-v2/src/utils/CasperRequestHandler.ts
+++ b/wallets/react-wallet-v2/src/utils/CasperRequestHandler.ts
@@ -19,7 +19,7 @@ export async function approveCasperRequest(
       return formatJsonRpcResult(id, signedMessage)
 
     case CASPER_SIGNING_METHODS.CASPER_SIGN_DEPLOY:
-      const deploy = DeployUtil.deployFromJson(request.params.deploy).unwrap()
+      const deploy = DeployUtil.deployFromJson(request.params).unwrap()
       const signedDeploy = await wallet.signDeploy(deploy)
 
       return formatJsonRpcResult(id, DeployUtil.deployToJson(signedDeploy))


### PR DESCRIPTION

![image](https://github.com/TheArcadiaGroup/casper-walletconnect-web-examples/assets/2131247/20c0c2f0-3603-4b39-85b7-6210da9bb54a)

as it can be seen in the screenshot, the deploy object in the request parameters is wrapped inside another deploy object, which is probably a confusion due to using the DeployUtil helper from the JS SDK. This PR removes one this duplication